### PR TITLE
Allow rootless containers to use AppArmor profiles

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -29,7 +29,6 @@ import (
 	"github.com/containers/common/libnetwork/etchosts"
 	"github.com/containers/common/libnetwork/resolvconf"
 	"github.com/containers/common/libnetwork/types"
-	"github.com/containers/common/pkg/apparmor"
 	"github.com/containers/common/pkg/chown"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/subscriptions"
@@ -50,6 +49,7 @@ import (
 	"github.com/containers/storage/pkg/lockfile"
 	stypes "github.com/containers/storage/types"
 	securejoin "github.com/cyphar/filepath-securejoin"
+	runcaa "github.com/opencontainers/runc/libcontainer/apparmor"
 	runcuser "github.com/opencontainers/runc/libcontainer/user"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
@@ -224,12 +224,12 @@ func (c *Container) generateSpec(ctx context.Context) (s *spec.Spec, cleanupFunc
 	}
 
 	// Apply AppArmor checks and load the default profile if needed.
-	if len(c.config.Spec.Process.ApparmorProfile) > 0 {
-		updatedProfile, err := apparmor.CheckProfileAndLoadDefault(c.config.Spec.Process.ApparmorProfile)
-		if err != nil {
-			return nil, nil, err
+	if profile := c.config.Spec.Process.ApparmorProfile; len(profile) > 0 {
+		if runcaa.IsEnabled() {
+			g.SetProcessApparmorProfile(profile)
+		} else if profile != "unconfined" {
+			return nil, nil, fmt.Errorf("profile %q specified but AppArmor is disabled", profile)
 		}
-		g.SetProcessApparmorProfile(updatedProfile)
 	}
 
 	if err := c.makeBindMounts(); err != nil {

--- a/pkg/specgen/generate/security_linux.go
+++ b/pkg/specgen/generate/security_linux.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/containers/common/libimage"
-	"github.com/containers/common/pkg/apparmor"
 	"github.com/containers/common/pkg/capabilities"
 	"github.com/containers/common/pkg/config"
 	cutil "github.com/containers/common/pkg/util"
@@ -13,6 +12,7 @@ import (
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/containers/podman/v4/pkg/util"
+	runcaa "github.com/opencontainers/runc/libcontainer/apparmor"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/sirupsen/logrus"
@@ -61,7 +61,7 @@ func setLabelOpts(s *specgen.SpecGenerator, runtime *libpod.Runtime, pidConfig s
 
 func setupApparmor(s *specgen.SpecGenerator, rtc *config.Config, g *generate.Generator) error {
 	hasProfile := len(s.ApparmorProfile) > 0
-	if !apparmor.IsEnabled() {
+	if !runcaa.IsEnabled() {
 		if hasProfile && s.ApparmorProfile != "unconfined" {
 			return fmt.Errorf("apparmor profile %q specified, but Apparmor is not enabled on this system", s.ApparmorProfile)
 		}

--- a/test/e2e/run_apparmor_test.go
+++ b/test/e2e/run_apparmor_test.go
@@ -9,21 +9,28 @@ import (
 	"path/filepath"
 
 	"github.com/containers/common/pkg/apparmor"
+	"github.com/containers/podman/v4/pkg/rootless"
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
+	runcaa "github.com/opencontainers/runc/libcontainer/apparmor"
 )
 
 // wip
 func skipIfAppArmorEnabled() {
-	if apparmor.IsEnabled() {
+	if runcaa.IsEnabled() {
 		Skip("Apparmor is enabled")
 	}
 }
 func skipIfAppArmorDisabled() {
-	if !apparmor.IsEnabled() {
+	if !runcaa.IsEnabled() {
 		Skip("Apparmor is not enabled")
+	}
+}
+func skipIfRootless() {
+	if rootless.IsRootless() {
+		Skip("Running test without root")
 	}
 }
 
@@ -43,6 +50,8 @@ var _ = Describe("Podman run", func() {
 
 	It("podman run no apparmor --privileged", func() {
 		skipIfAppArmorDisabled()
+		// Root is required to use --privileged
+		skipIfRootless()
 		session := podmanTest.Podman([]string{"create", "--privileged", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -67,6 +76,8 @@ var _ = Describe("Podman run", func() {
 
 	It("podman run apparmor aa-test-profile", func() {
 		skipIfAppArmorDisabled()
+		// Root is required to load the AppArmor profile into the kernel with apparmor_parser
+		skipIfRootless()
 		aaProfile := `
 #include <tunables/global>
 profile aa-test-profile flags=(attach_disconnected,mediate_deleted) {

--- a/test/test_podman_baseline.sh
+++ b/test/test_podman_baseline.sh
@@ -536,11 +536,10 @@ EOF
     else
         echo "failed"
     fi
-    #Expected to fail (as rootless)
     sudo -u "#1000" podman run --security-opt apparmor=$aaProfile docker.io/library/alpine:latest echo hello
     rc=$?
     echo -n "rootless with specified AppArmor profile: "
-    if [ $rc != 0 ]; then
+    if [ $rc == 0 ]; then
         echo "passed"
     else
         echo "failed"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

Related issues:
- https://github.com/containers/common/issues/958 (closed in https://github.com/containers/common/pull/960, reverted by https://github.com/containers/common/pull/969)
- https://github.com/containers/podman/issues/15874

As previously noted in https://github.com/containers/common/issues/958 and https://github.com/containers/podman/issues/15874, it is perfectly possible for rootless containers to run with an AppArmor profile. However, the current architecture of Podman requires it to load the default AppArmor profile at runtime before running the container. With this PR, we no longer attempt to load the profile at runtime. Instead (as discussed in https://github.com/containers/podman/issues/15874), default profiles should be installed to `/etc/apparmor.d/` at the point where Podman is installed, and then specified in a default `containers.conf`.

This is the sister PR to https://github.com/containers/common/pull/1572; they should be merged in together to avoid breakage.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
